### PR TITLE
Cleanup: Removes deprecated method, style, deleted unused code

### DIFF
--- a/Kea/Main.cs
+++ b/Kea/Main.cs
@@ -165,7 +165,7 @@ namespace Kea
                     i++;
                     processInfo.Invoke((MethodInvoker)delegate { processInfo.Text = $"scoping tab {i}"; }); //run on the UI thread
                     client.Headers.Add("Cookie", "pagGDPR=true;");  //add cookies to bypass age verification
-                    WebProxy proxy = WebProxy.GetDefaultProxy();    //add default proxy
+                    IWebProxy proxy = WebRequest.DefaultWebProxy;   //add default proxy
                     client.Proxy = proxy;
                     string html = await client.DownloadStringTaskAsync(line.Substring(0, urlEnd) + "&page=" + i);
                     HtmlAgilityPack.HtmlDocument doc = new HtmlAgilityPack.HtmlDocument();   //HtmlAgility magic
@@ -232,7 +232,7 @@ namespace Kea
                 using (WebClient client = new WebClient())
                 {
                     client.Headers.Add("Cookie", "pagGDPR=true;");  //add cookies to bypass age verification
-                    WebProxy proxy = WebProxy.GetDefaultProxy();    //add default proxy
+                    IWebProxy proxy = WebRequest.DefaultWebProxy;    //add default proxy
                     client.Proxy = proxy;
                     string html = client.DownloadString(ToonChapters[t][i]);
                     HtmlAgilityPack.HtmlDocument doc = new HtmlAgilityPack.HtmlDocument();

--- a/Kea/Main.cs
+++ b/Kea/Main.cs
@@ -119,7 +119,7 @@ namespace Kea
             EnableControls(minimizeBtn);
             await DownloadQueueAsync();
             EnableAllControls(this);
-            if(saveAs != "multiple images") chapterFoldersCB.Enabled = false;
+            if (saveAs != "multiple images") chapterFoldersCB.Enabled = false;
         }
 
         private async Task DownloadQueueAsync()

--- a/Kea/Main.cs
+++ b/Kea/Main.cs
@@ -1,7 +1,4 @@
-﻿using HtmlAgilityPack;
-using iTextSharp.text;
-using iTextSharp.text.pdf;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -13,6 +10,9 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using HtmlAgilityPack;
+using iTextSharp.text;
+using iTextSharp.text.pdf;
 using Image = iTextSharp.text.Image;
 using Rectangle = iTextSharp.text.Rectangle;
 
@@ -66,7 +66,7 @@ namespace Kea
         {
             List<string> lines = new List<string>();
             lines.AddRange(URLTextbox.Text.Split('\n'));
-            foreach (var line in lines)
+            foreach (string line in lines)
             {
                 int nameEnd = 0;
                 int nameStart = 0;
@@ -83,7 +83,7 @@ namespace Kea
                 }
                 catch { continue; }
                 if (QueueTextbox.Text.Contains($"/{line.Substring(nameStart, nameEnd - nameStart - 1)}/")) { continue; }
-                QueueTextbox.Text += (QueueTextbox.Text == "") ? line: "\n" + line;
+                QueueTextbox.Text += (QueueTextbox.Text == "") ? line : "\n" + line;
                 QueueGrid.Rows.Add(line.Substring(nameStart, nameEnd - nameStart - 1), "1", "end");
             }
             URLTextbox.Text = "";
@@ -97,20 +97,20 @@ namespace Kea
                 try
                 {
                     start = int.Parse(r.Cells[1].Value.ToString());
-                    if(start < 1) { MessageBox.Show("The start chapter must be greater than zero!"); return; }
+                    if (start < 1) { MessageBox.Show("The start chapter must be greater than zero!"); return; }
                 }
                 catch { MessageBox.Show("The start chapter must be a number!"); return; }
 
-                try 
-                { 
+                try
+                {
                     end = int.Parse(r.Cells[2].Value.ToString());
                     if (end < 1) { MessageBox.Show("The end chapter must be greater than zero!"); return; }
                 }
                 catch
                 {
-                    if(r.Cells[2].Value.ToString() != "end") { MessageBox.Show("The end chapter must be a number or the word 'end'!"); return; }
+                    if (r.Cells[2].Value.ToString() != "end") { MessageBox.Show("The end chapter must be a number or the word 'end'!"); return; }
                 }
-                if(end != 0 && end < start) { MessageBox.Show("The start chapter must smaller than the end chapter!"); return; }
+                if (end != 0 && end < start) { MessageBox.Show("The start chapter must smaller than the end chapter!"); return; }
             }
             DisableAllControls(this);
             saveAs = saveAsOption.Text;
@@ -168,9 +168,9 @@ namespace Kea
                     WebProxy proxy = WebProxy.GetDefaultProxy();    //add default proxy
                     client.Proxy = proxy;
                     string html = await client.DownloadStringTaskAsync(line.Substring(0, urlEnd) + "&page=" + i);
-                    var doc = new HtmlAgilityPack.HtmlDocument();   //HtmlAgility magic
+                    HtmlAgilityPack.HtmlDocument doc = new HtmlAgilityPack.HtmlDocument();   //HtmlAgility magic
                     doc.LoadHtml(html);
-                    var div = doc.GetElementbyId("_listUl");
+                    HtmlNode div = doc.GetElementbyId("_listUl");
                     HtmlNodeCollection childNodes = div.ChildNodes;
                     checkedForLink = false;
                     for (int j = 0; j < childNodes.Count; j++)
@@ -235,11 +235,11 @@ namespace Kea
                     WebProxy proxy = WebProxy.GetDefaultProxy();    //add default proxy
                     client.Proxy = proxy;
                     string html = client.DownloadString(ToonChapters[t][i]);
-                    var doc = new HtmlAgilityPack.HtmlDocument();
+                    HtmlAgilityPack.HtmlDocument doc = new HtmlAgilityPack.HtmlDocument();
                     doc.LoadHtml(html);
-                    var div = doc.GetElementbyId("_imageList");
+                    HtmlNode div = doc.GetElementbyId("_imageList");
                     HtmlNodeCollection childNodes = div.ChildNodes;
-                    if (chapterFoldersCB.Checked || saveAs != "multiple images") { Directory.CreateDirectory(savePath + @"\" + $"({i+1}) {ToonChapterNames[t][i]}"); }
+                    if (chapterFoldersCB.Checked || saveAs != "multiple images") { Directory.CreateDirectory(savePath + @"\" + $"({i + 1}) {ToonChapterNames[t][i]}"); }
                     for (int j = 0; j < childNodes.Count; j++)  //...download all images!
                     {
                         if (childNodes[j].NodeType == HtmlNodeType.Element)
@@ -247,7 +247,7 @@ namespace Kea
                             processInfo.Invoke((MethodInvoker)delegate { processInfo.Text = $"downloading image {j / 2} of chapter {i + 1} of the comic \"{curName}\"!"; }); //run on the UI thread
                             client.Headers.Add("Referer", ToonChapters[t][i]);    //refresh the referer for each request!
                             string imgName = $"{curName} Ch{i + 1}.{j / 2}";
-                            if (chapterFoldersCB.Checked || saveAs != "multiple images") { client.DownloadFile(new Uri(childNodes[j].Attributes["data-url"].Value), $"{savePath}\\({i+1}) {ToonChapterNames[t][i]}\\{imgName}.jpg"); }
+                            if (chapterFoldersCB.Checked || saveAs != "multiple images") { client.DownloadFile(new Uri(childNodes[j].Attributes["data-url"].Value), $"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}\\{imgName}.jpg"); }
                             else { client.DownloadFile(new Uri(childNodes[j].Attributes["data-url"].Value), $"{savePath}\\{imgName}.jpg"); }
                             processInfo.Invoke((MethodInvoker)delegate { try { progressBar.Value = i * 100 + (int)(j / (float)childNodes.Count * 100); } catch { } });
                         }
@@ -276,12 +276,12 @@ namespace Kea
                     finally { doc.Close(); }
                     Directory.Delete($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}", true);
                 }
-                else if(saveAs == "one image (may be lower in quality)") //bundle images into one long image
+                else if (saveAs == "one image (may be lower in quality)") //bundle images into one long image
                 {
                     DirectoryInfo di = new DirectoryInfo($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}");
                     FileInfo[] fileInfos = di.GetFiles("*.jpg").OrderBy(fi => fi.CreationTime).ToArray();
                     string[] files = fileInfos.Select(o => o.FullName).ToArray();
-                    
+
                     Bitmap[] images = new Bitmap[files.Length];
                     int finalHeight = 0;
                     for (int j = 0; j < images.Length; j++)
@@ -290,7 +290,7 @@ namespace Kea
                         finalHeight += images[j].Height;
                     }
 
-                    using (var bm = new Bitmap(images[0].Width, finalHeight))
+                    using (Bitmap bm = new Bitmap(images[0].Width, finalHeight))
                     {
                         int pointerHeight = 0;
                         using (Graphics g = Graphics.FromImage(bm))
@@ -308,13 +308,13 @@ namespace Kea
                         }
                         else bm.Save($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}.png");
                     }
-                    foreach (var image in images)
+                    foreach (Bitmap image in images)
                     {
                         image.Dispose();
                     }
                     Directory.Delete($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}", true);
                 }
-                else if(saveAs == "CBZ file")
+                else if (saveAs == "CBZ file")
                 {
                     ZipFile.CreateFromDirectory($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}", $"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}.cbz");
                     Directory.Delete($"{savePath}\\({i + 1}) {ToonChapterNames[t][i]}", true);
@@ -324,12 +324,12 @@ namespace Kea
 
         public static Bitmap ResizeImage(System.Drawing.Image image, int width, int height)
         {
-            var destRect = new System.Drawing.Rectangle(0, 0, width, height);
-            var destImage = new Bitmap(width, height);
+            System.Drawing.Rectangle destRect = new System.Drawing.Rectangle(0, 0, width, height);
+            Bitmap destImage = new Bitmap(width, height);
 
             destImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
-            using (var graphics = Graphics.FromImage(destImage))
+            using (Graphics graphics = Graphics.FromImage(destImage))
             {
                 graphics.CompositingMode = CompositingMode.SourceCopy;
                 graphics.CompositingQuality = CompositingQuality.HighQuality;
@@ -337,7 +337,7 @@ namespace Kea
                 graphics.SmoothingMode = SmoothingMode.HighQuality;
                 graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
-                using (var wrapMode = new ImageAttributes())
+                using (ImageAttributes wrapMode = new ImageAttributes())
                 {
                     wrapMode.SetWrapMode(WrapMode.TileFlipXY);
                     graphics.DrawImage(image, destRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, wrapMode);
@@ -358,11 +358,13 @@ namespace Kea
 
         private void selectFolderBtn_Click(object sender, EventArgs e)
         {
-            OpenFileDialog ofile = new OpenFileDialog();
-            ofile.ValidateNames = false;
-            ofile.CheckFileExists = false;
-            ofile.CheckPathExists = true;
-            ofile.FileName = "Folder Selection";
+            OpenFileDialog ofile = new OpenFileDialog
+            {
+                ValidateNames = false,
+                CheckFileExists = false,
+                CheckPathExists = true,
+                FileName = "Folder Selection"
+            };
             if (DialogResult.OK == ofile.ShowDialog())
             {
                 savepathTB.Text = Path.GetDirectoryName(ofile.FileName);
@@ -384,7 +386,7 @@ namespace Kea
             QueueTextbox.Text = "";
             string name = QueueGrid.SelectedRows[0].Cells[0].Value.ToString();
             QueueGrid.Rows.RemoveAt(QueueGrid.SelectedRows[0].Index);
-            foreach (var line in lines)
+            foreach (string line in lines)
             {
                 if (!line.Contains($"/{name}/")) { QueueTextbox.Text += line + "\n"; }
             }
@@ -406,7 +408,7 @@ namespace Kea
 
         private void saveAsOption_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if(saveAsOption.Text == "multiple images")
+            if (saveAsOption.Text == "multiple images")
             {
                 chapterFoldersCB.Enabled = true;
                 chapterFoldersCB.Checked = true;

--- a/Kea/Program.cs
+++ b/Kea/Program.cs
@@ -1,18 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Kea
 {
-    static class Program
+    internal static class Program
     {
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        private static void Main()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/Kea/Properties/AssemblyInfo.cs
+++ b/Kea/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
This PR removes the deprecated `WebProxy.GetDefaultProxy();` with `WebRequest.DefaultWebProxy`, [which I think is the recommended way to use the default proxy](https://docs.microsoft.com/en-us/dotnet/api/system.net.webproxy.getdefaultproxy?view=net-5.0).

I also used Visual Studio Code's automated code cleanup tool (double-checking to ensure that current code style is maintained) to remove unused code, keep consistent style, and make code more readable. This also explicitly defines some variables.

Feel free to accept some/none of this, I just wanted to send a PR with these changes to the main repo as I cleaned up the code while I was poking around at how this program works! 😄